### PR TITLE
chg: Bump remote to 0.5

### DIFF
--- a/remote.rb
+++ b/remote.rb
@@ -2,8 +2,8 @@ class Remote < Formula
   desc "CLI to connect to AWS instances"
   homepage "https://github.com/wellcometrust/remote/"
   url "https://github.com/wellcometrust/remote/tarball/a51eef8cec1734c6eae2e24388f30f32cbda51a7"
-  version "0.4"
-  sha256 "5bbb449d80af9753d5086831bf3315e4a0c5dac93eb10a126eec2925bc19da4e"
+  version "0.5"
+  sha256 "e5f5875f55a4a5cf4e20f90259ebfa7df656a5424ffc1dd97c95f67cbd13530b"
 
   depends_on "awscli"
   


### PR DESCRIPTION
* Filters out terminated instances
* Adds `remote ip` command